### PR TITLE
[gh37] Hotwired the Tags page

### DIFF
--- a/nextjs/src/modules/shared/components/Header/Header.js
+++ b/nextjs/src/modules/shared/components/Header/Header.js
@@ -22,7 +22,7 @@ const Header = () => {
 
   return (
     <StyledHeader>
-      <Navigation isShowing={navShowing} />
+      <Navigation isShowing={navShowing} handleClick={handleClick} />
       <Hamburger className="hamburger" onClick={handleClick} />
 
       <div>

--- a/nextjs/src/modules/shared/components/Header/components/Navigation.js
+++ b/nextjs/src/modules/shared/components/Header/components/Navigation.js
@@ -16,7 +16,7 @@ import { SearchForm } from './SearchForm';
 /** -------------------------------------------------
 * COMPONENT
 ---------------------------------------------------- */
-const Navigation = ({ isShowing }) => {
+const Navigation = ({ handleClick, isShowing }) => {
   const [tags, setTags] = useState();
 
   // GET TAGS
@@ -41,7 +41,7 @@ const Navigation = ({ isShowing }) => {
           {tags &&
             tags.map((tag) => (
               <li key={tag._id}>
-                <Tag name={tag.title} />
+                <Tag name={tag.title} handleClick={handleClick} />
               </li>
             ))}
         </ul>
@@ -52,10 +52,12 @@ const Navigation = ({ isShowing }) => {
 
 Navigation.propTypes = {
   isShowing: PropTypes.bool,
+  handleClick: PropTypes.func,
 };
 
 Navigation.defaultProps = {
   isShowing: false,
+  handleClick: () => { },
 };
 
 /** -------------------------------------------------

--- a/nextjs/src/modules/shared/components/Header/components/Tag.js
+++ b/nextjs/src/modules/shared/components/Header/components/Tag.js
@@ -6,16 +6,21 @@ import { slugify } from 'utils/slugify';
 /** -------------------------------------------------
 * COMPONENT
 ---------------------------------------------------- */
-const Tag = ({ name }) => (
+const Tag = ({ handleClick, name }) => (
   <StyledTag>
     <Link href={`/tag/${slugify(name)}`}>
-      <a>{name}</a>
+      <a onClick={handleClick}>{name}</a>
     </Link>
   </StyledTag>
 );
 
 Tag.propTypes = {
+  handleClick: PropTypes.func,
   name: PropTypes.string.isRequired,
+};
+
+Tag.defaultProps = {
+  handleClick: () => { },
 };
 
 /** -------------------------------------------------

--- a/nextjs/src/modules/tag/TagPage.js
+++ b/nextjs/src/modules/tag/TagPage.js
@@ -12,18 +12,33 @@ import { MixinSectionHeading, MixinPageTitle } from 'styles/Typography';
 /** -------------------------------------------------
 * COMPONENT
 ---------------------------------------------------- */
-const TagPage = ({ episodes }) => (
-  <StyledTagPage>
-    <h3>Tagged</h3>
-    <h1>Career Development</h1>
-    <EpisodeGrid episodes={episodes} />
-    <VerticalDivider />
-    <Newsletter />
-  </StyledTagPage>
-);
+const TagPage = ({ content }) => {
+  const { title, episodes } = content.content;
+  console.log({ title, episodes });
+  return (
+    <StyledTagPage>
+      <h3>Tagged</h3>
+      {title && <h1>{title}</h1>}
+      {episodes ? (
+        <EpisodeGrid episodes={episodes} />
+      ) : (
+        <p>
+          <em>No Episodes Found</em>
+        </p>
+      )}
+      <VerticalDivider />
+      <Newsletter />
+    </StyledTagPage>
+  );
+};
 
 TagPage.propTypes = {
-  episodes: PropTypes.array.isRequired,
+  content: PropTypes.shape({
+    content: PropTypes.shape({
+      title: PropTypes.string,
+      episodes: PropTypes.array,
+    }),
+  }).isRequired,
 };
 
 /** -------------------------------------------------

--- a/nextjs/src/pages/tag/[slug].js
+++ b/nextjs/src/pages/tag/[slug].js
@@ -3,15 +3,21 @@ import groq from 'groq';
 import { TagPage } from 'modules/tag';
 import { InteriorLayout } from 'modules/shared/layouts/InteriorLayout';
 
-export default function Tag({tags}) {
-  return <InteriorLayout>{/* <TagPage episodes={content} /> */}</InteriorLayout>;
+export default function Tag(props) {
+  console.log('inside page/tag');
+  console.log(props);
+  return (
+    <InteriorLayout>
+      <TagPage content={props} />
+    </InteriorLayout>
+  );
 }
 
-const query = groq`*[_type == "category"] {
+const query = groq`*[_type == "category" && slug.current == $slug ] {
   _id,
   title,
   description,
-  "episodes": *[_type=='' && references(^._id)] {
+  "episodes": *[_type=='episode' && references(^._id)] {
     title,
     categories[]->,
     episodeNumber,
@@ -20,10 +26,10 @@ const query = groq`*[_type == "category"] {
     briefDescription,
     audioPath
   }
-}`;
+}[0]`;
 
 export async function getServerSideProps(context) {
   const { slug = '' } = context.query;
-  const tags = await client.fetch(query, { slug });
-  return {props: {tags}};
-};
+  const content = await client.fetch(query, { slug });
+  return { props: { content } };
+}


### PR DESCRIPTION
- Also fixed navigation so that when you’re navigating between multiple tag pages, the nav will close.
- Closes #37

## Feature description
- The Tag page was not hotwired to Sanity. Needed to load the title and a grid of episodes with that specific tag.

## Solution description
- Hotwired the page
- Updated the groq query

## Address affected and ensured
- Fixed an issue: if you were on the tag page and tried to navigate to another tag page, the nav wouldn't close. It appeared as if you weren't going anywhere.