### PR TITLE
[gh19] Pagination on the Individual Newsletter Page

### DIFF
--- a/nextjs/src/modules/episodes/EpisodePage.js
+++ b/nextjs/src/modules/episodes/EpisodePage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 // components
@@ -6,7 +7,6 @@ import { Newsletter } from 'modules/shared/components/Newsletter';
 import { Podcatchers } from 'modules/shared/components/Podcatchers';
 import { FeaturedEpisode } from 'modules/home/components/FeaturedEpisode';
 import { VerticalDivider } from 'modules/shared/components/VerticalDivider';
-import { HorizontalDivider } from 'modules/shared/components/HorizontalDivider';
 
 /** -------------------------------------------------
 * COMPONENT
@@ -14,7 +14,7 @@ import { HorizontalDivider } from 'modules/shared/components/HorizontalDivider';
 const EpisodePage = ({ episodes }) => {
   // get the first element in the array to feature
   const featuredEpisode = episodes[0];
-  const remainingEpisodes = episodes.slice(1)
+  const remainingEpisodes = episodes.slice(1);
   return (
     <StyledEpisodePage>
       {featuredEpisode && (
@@ -30,6 +30,10 @@ const EpisodePage = ({ episodes }) => {
       <Newsletter />
     </StyledEpisodePage>
   );
+};
+
+EpisodePage.propTypes = {
+  episodes: PropTypes.array.isRequired,
 };
 
 /** -------------------------------------------------

--- a/nextjs/src/modules/newsletter/IndividualNewsletterPage.js
+++ b/nextjs/src/modules/newsletter/IndividualNewsletterPage.js
@@ -3,18 +3,14 @@ import Head from 'next/head';
 import styled from 'styled-components';
 import BlockContent from '@sanity/block-content-to-react';
 
-// components
-import { serializers } from 'modules/shared/blockContent/Serializers';
-import { Newsletter } from 'modules/shared/components/Newsletter';
-import { VerticalDivider } from 'modules/shared/components/VerticalDivider';
-import { Meta } from 'modules/shared/components/Meta';
-
-// styles
 import { Breakpoints } from 'styles/Breakpoints';
-import { MixinBodyCopy, MixinPageTitle, MixinSectionHeading } from 'styles/Typography';
-
-// utils
 import { formatShortDate } from 'utils/dateHelpers';
+import { Meta } from 'modules/shared/components/Meta';
+import { MixinBodyCopy, MixinPageTitle, MixinSectionHeading } from 'styles/Typography';
+import { Newsletter } from 'modules/shared/components/Newsletter';
+import { serializers } from 'modules/shared/blockContent/Serializers';
+import { VerticalDivider } from 'modules/shared/components/VerticalDivider';
+import { NewsletterPagination } from './components/NewsletterPagination';
 
 /** -------------------------------------------------
 * COMPONENT
@@ -35,6 +31,7 @@ const IndividualNewsletterPage = ({ dateSent, subject, content, meta, pagination
       </main>
 
       {/* pagination */}
+      <NewsletterPagination pagination={pagination} />
 
       <VerticalDivider />
 

--- a/nextjs/src/modules/newsletter/components/NewsletterPagination.js
+++ b/nextjs/src/modules/newsletter/components/NewsletterPagination.js
@@ -2,36 +2,51 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import { Icon } from 'modules/shared/components/Icon';
+import { Breakpoints } from 'styles/Breakpoints';
+import { formatLongDate } from 'utils/dateHelpers';
 
 /** -------------------------------------------------
 * COMPONENT
 ---------------------------------------------------- */
-const NewsletterPagination = ({ pagination }) => (
-  <StyledNewsletterPagination>
-    <div className="pagination">
-      <div className="Next">
-        {pagination.next && (
-          <Link href={`/newsletter/${pagination.next.slug}`}>
-            <a>
-              <Icon name="arrow" />
-              {pagination.next.subject}
-            </a>
-          </Link>
-        )}
+const NewsletterPagination = ({ pagination }) => {
+  const { previous, next } = pagination;
+  return (
+    <StyledNewsletterPagination>
+      <div className="pagination">
+        <div className="next">
+          {/* NEXT */}
+          {next && next?.published && (
+            <Link href={`/newsletter/${next.slug.current}`}>
+              <a>
+                <div className="arrow">
+                  <Icon name="arrow" className="left-arrow" />
+                  Next
+                </div>
+                <div className="date">{formatLongDate(next.dateSent)}</div>
+                <div className="subject">{next.subject}</div>
+              </a>
+            </Link>
+          )}
+        </div>
+        {/* PREVIOUS */}
+        <div className="previous">
+          {previous && previous?.published && (
+            <Link href={`/newsletter/${previous.slug.current}`}>
+              <a>
+                <div className="arrow">
+                  Previous
+                  <Icon name="arrow" />
+                </div>
+                <div className="date">{formatLongDate(previous.dateSent)}</div>
+                <div className="subject">{previous.subject}</div>
+              </a>
+            </Link>
+          )}
+        </div>
       </div>
-      <div className="previous">
-        {pagination.previous && (
-          <Link href={`/newsletter/${pagination.previous.slug}`}>
-            <a>
-              <Icon name="arrow" />
-              {pagination.previous.subject}
-            </a>
-          </Link>
-        )}
-      </div>
-    </div>
-  </StyledNewsletterPagination>
-);
+    </StyledNewsletterPagination>
+  );
+};
 
 NewsletterPagination.propTypes = {
   pagination: PropTypes.any.isRequired,
@@ -40,6 +55,107 @@ NewsletterPagination.propTypes = {
 /** -------------------------------------------------
 * STYLES
 ---------------------------------------------------- */
-const StyledNewsletterPagination = styled.section``;
+const StyledNewsletterPagination = styled.section`
+  .pagination {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-areas: 'next previous';
+    max-width: ${(props) => props.theme.pageWidth};
+    margin: 0 auto;
+
+    a {
+      text-decoration: none;
+    }
+
+    .arrow {
+      color: ${(props) => props.theme.yellow};
+      font-family: ${(props) => props.theme.mono};
+      font-size: 1.8rem;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      letter-spacing: 0.25rem;
+      margin-bottom: 10px;
+    }
+
+    .date {
+      color: ${(props) => props.theme.white};
+      font-family: ${(props) => props.theme.sansSerif};
+      font-size: 1.8rem;
+      margin-bottom: 10px;
+    }
+
+    .subject {
+      font-family: ${(props) => props.theme.sansSerif};
+      font-weight: ${(props) => props.theme.fontBlack};
+      color: ${(props) => props.theme.white};
+      font-size: 3.2rem;
+      line-height: 1.2;
+    }
+
+    a:hover .date,
+    a:hover .subject {
+      color: ${(props) => props.theme.yellow};
+    }
+
+    .next,
+    .previous {
+      padding: 40px;
+    }
+
+    .next {
+      grid-area: next;
+
+      @media (${Breakpoints.large}) {
+        padding-left: 0;
+      }
+
+      .arrow {
+        position: relative;
+        left: -30px;
+      }
+
+      .left-arrow {
+        transform: rotate(180deg);
+      }
+
+      svg {
+        left: 0;
+        position: relative;
+        transition: left 0.25s ease-in-out;
+      }
+
+      a:hover svg {
+        left: -10px;
+      }
+    }
+
+    .previous {
+      grid-area: previous;
+      text-align: right;
+
+      @media (${Breakpoints.large}) {
+        padding-right: 0;
+      }
+
+      .arrow {
+        position: relative;
+        right: -30px;
+        margin-left: auto;
+        justify-content: flex-end;
+      }
+
+      svg {
+        right: 0;
+        position: relative;
+        transition: right 0.25s ease-in-out;
+      }
+
+      a:hover svg {
+        right: -10px;
+      }
+    }
+  }
+`;
 
 export { NewsletterPagination };

--- a/nextjs/src/pages/newsletter/[slug].js
+++ b/nextjs/src/pages/newsletter/[slug].js
@@ -3,7 +3,7 @@ import groq from 'groq';
 import { InteriorLayout } from 'modules/shared/layouts/InteriorLayout';
 import { IndividualNewsletterPage } from 'modules/newsletter/IndividualNewsletterPage';
 
-export default function IndividualNewsletter({newsletter}) {
+export default function IndividualNewsletter({ newsletter }) {
   return (
     <InteriorLayout>
       <IndividualNewsletterPage {...newsletter} />
@@ -38,20 +38,21 @@ const query = groq`*[_type == "newsletter" && slug.current == $slug] | order(dat
     next->{
       subject,
       dateSent,
-      slug
+      slug,
+      published
     },
     previous->{
       subject,
       dateSent,
-      slug
+      slug,
+      published
     }
   },
   meta
 }[0]`;
 
-
 export async function getServerSideProps(context) {
   const { slug = '' } = context.query;
   const newsletter = await client.fetch(query, { slug });
-  return {props: {newsletter}}
+  return { props: { newsletter } };
 }

--- a/nextjs/src/pages/newsletter/index.js
+++ b/nextjs/src/pages/newsletter/index.js
@@ -3,7 +3,7 @@ import groq from 'groq';
 import { InteriorLayout } from 'modules/shared/layouts/InteriorLayout';
 import { NewsletterPage } from 'modules/newsletter';
 
-export default function Newsletter({newsletters}) {
+export default function Newsletter({ newsletters }) {
   return (
     <InteriorLayout>
       <NewsletterPage newsletters={newsletters} />
@@ -20,5 +20,5 @@ const query = groq`*[_type == "newsletter" && published == true] | order(dateSen
 
 export async function getServerSideProps(context) {
   const newsletters = await client.fetch(query);
-  return {props: {newsletters}}
-};
+  return { props: { newsletters } };
+}


### PR DESCRIPTION
## Feature description
Added pagination to the newsletter page. Fixes #19 

## Solution description
- Added pagination to the bottom of the individual newsletter page.
- Previous and next page links are set within individual Sanity entries

## Output Screenshots
<img width="1176" alt="CleanShot 2021-06-16 at 16 22 59@2x" src="https://user-images.githubusercontent.com/212300/122287637-c76b4d80-ceb6-11eb-9fef-a1e1a16020da.png">

## Address affected and ensured
- Fixed linting on a few pages
