### PR TITLE
[gh36] RSS in footer

### DIFF
--- a/nextjs/src/modules/shared/components/Footer/Footer.js
+++ b/nextjs/src/modules/shared/components/Footer/Footer.js
@@ -42,6 +42,7 @@ const Footer = ({ props }) => {
         instagram={Constants.COMPRESSEDFM_INSTAGRAM_URL}
         github={Constants.COMPRESSEDFM_GITHUB_URL}
         twitter={Constants.COMPRESSEDFM_TWITTER_URL}
+        rss={Constants.COMPRESSEDFM_RSS}
       />
 
       <div className="links-wrapper">

--- a/nextjs/src/modules/shared/components/Icon/Rss.js
+++ b/nextjs/src/modules/shared/components/Icon/Rss.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 
-const Rss = ({ className, height, width }) => {
-  console.log('getting here');
-  return <span>Howdy</span>;
-};
+const Rss = ({ className, height, width }) => (
+  <svg className={className} width={width} height={height} viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6.6,29c2,0,3.6-1.6,3.6-3.6s-1.6-3.6-3.6-3.6c-2,0-3.6,1.6-3.6,3.6S4.6,29,6.6,29z" />
+    <path d="M3,3v4.7c11.7,0,21.3,9.5,21.3,21.3H29C29,14.6,17.4,3,3,3z M3,12.5v4.7c6.5,0,11.8,5.3,11.8,11.8h4.7 C19.5,19.9,12.1,12.5,3,12.5z" />
+  </svg>
+);
 
 Rss.propTypes = {
   className: PropTypes.string,

--- a/nextjs/src/modules/shared/components/Icon/Rss.js
+++ b/nextjs/src/modules/shared/components/Icon/Rss.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+
+const Rss = ({ className, height, width }) => {
+  console.log('getting here');
+  return <span>Howdy</span>;
+};
+
+Rss.propTypes = {
+  className: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string,
+};
+
+Rss.defaultProps = {
+  className: '',
+  height: '32',
+  width: '32',
+};
+
+export { Rss };

--- a/nextjs/src/modules/shared/components/Icon/index.js
+++ b/nextjs/src/modules/shared/components/Icon/index.js
@@ -10,12 +10,15 @@ import { LinkedIn } from './LinkedIn';
 import { Minus } from './Minus';
 import { Pinterest } from './Pinterest';
 import { Plus } from './Plus';
+import { Rss } from './Rss';
 import { Twitch } from './Twitch';
 import { Twitter } from './Twitter';
 import { YouTube } from './YouTube';
 
 const Icon = (props) => {
-  switch (props.name.toLowerCase()) {
+  const { name } = props;
+  console.log(name);
+  switch (name.toLowerCase()) {
     case 'arrow':
       return <Arrow {...props} />;
     case 'dribbble':
@@ -34,6 +37,8 @@ const Icon = (props) => {
       return <Pinterest {...props} />;
     case 'plus':
       return <Plus {...props} />;
+    case 'rss':
+      return <Rss {...props} />;
     case 'twitch':
       return <Twitch {...props} />;
     case 'twitter':

--- a/nextjs/src/modules/shared/components/SocialMedia/SocialMedia.js
+++ b/nextjs/src/modules/shared/components/SocialMedia/SocialMedia.js
@@ -101,13 +101,13 @@ const SocialMedia = ({
     )}
 
     {/*  RSS */}
-    {/* {rss && ( */}
-    <li>
-      <a href={rss} target="_blank" rel="noreferrer">
-        <Icon name="rss" />
-      </a>
-    </li>
-    {/* )} */}
+    {rss && (
+      <li>
+        <a href={rss} target="_blank" rel="noreferrer">
+          <Icon name="rss" />
+        </a>
+      </li>
+    )}
   </StyledSocialMedia>
 );
 

--- a/nextjs/src/modules/shared/components/SocialMedia/SocialMedia.js
+++ b/nextjs/src/modules/shared/components/SocialMedia/SocialMedia.js
@@ -2,6 +2,9 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon } from 'modules/shared/components/Icon';
 
+/** -------------------------------------------------
+* COMPONENT
+---------------------------------------------------- */
 const SocialMedia = ({
   className,
   dribbble,
@@ -11,6 +14,7 @@ const SocialMedia = ({
   linkedin,
   twitch,
   twitter,
+  rss,
   pinterest,
   youtube,
 }) => (
@@ -95,6 +99,15 @@ const SocialMedia = ({
         </a>
       </li>
     )}
+
+    {/*  RSS */}
+    {/* {rss && ( */}
+    <li>
+      <a href={rss} target="_blank" rel="noreferrer">
+        <Icon name="rss" />
+      </a>
+    </li>
+    {/* )} */}
   </StyledSocialMedia>
 );
 
@@ -108,6 +121,7 @@ SocialMedia.propTypes = {
   pinterest: PropTypes.string,
   twitch: PropTypes.string,
   twitter: PropTypes.string,
+  rss: PropTypes.string,
   youtube: PropTypes.string,
 };
 
@@ -121,9 +135,13 @@ SocialMedia.defaultProps = {
   pinterest: '',
   twitch: '',
   twitter: '',
+  rss: '',
   youtube: '',
 };
 
+/** -------------------------------------------------
+* STYLES
+---------------------------------------------------- */
 const StyledSocialMedia = styled.ul`
   align-items: center;
   color: ${(props) => props.theme.lavenderIndigo};

--- a/nextjs/src/utils/constants.js
+++ b/nextjs/src/utils/constants.js
@@ -12,6 +12,7 @@ const Constants = Object.freeze({
   COMPRESSEDFM_GITHUB_URL: 'http://github.com/compressedfm',
   COMPRESSEDFM_INSTAGRAM_URL: 'http://instagram.com/compressedfm',
   COMPRESSEDFM_TWITTER_URL: 'http://twitter.com/compressedfm',
+  COMPRESSEDFM_RSS: 'https://feeds.simplecast.com/hq7M2S7s',
 
   // james
   JAMES_WEBSITE_URL: 'http://jamesqquick.com',


### PR DESCRIPTION
Fixes #36 

## Feature description
- Added the RSS icon to the social media links in the footer

## Solution description
- Added an RSS icon to the `Icon` component
- Added the RSS feed URL to the constants file
- Added the RSS feed to the Social Media component

## Output Screenshots
<img width="369" alt="CleanShot 2021-06-16 at 16 37 56@2x" src="https://user-images.githubusercontent.com/212300/122289924-db17b380-ceb8-11eb-89ad-7e10c6ab0d8e.png">

## Address affected and ensured
- There's a section of settings within Sanity for social media links, but all the social media links within the footer are pulling from the Constants file (inside utils)