### PR TITLE
FIX: Playback speed doesn't reset to 1X

### DIFF
--- a/nextjs/src/modules/shared/components/AudioPlayer/hooks/AudioPlayer.js
+++ b/nextjs/src/modules/shared/components/AudioPlayer/hooks/AudioPlayer.js
@@ -71,6 +71,7 @@ export const useAudioPlayer = (audioRef, progressBarRef) => {
         break;
       case 2:
       default:
+        audioRef.current.playbackRate = 1;
         setSpeed(1);
         break;
     }


### PR DESCRIPTION
@ahaywood Thanks for your YouTube video on Build a Custom Audio Player in React. I'm currently redesigning a podcast website and the video is very useful to me. 
