### PR TITLE
[gh71] Episode cover artwork displays the correct image.

### DIFF
--- a/nextjs/src/modules/episodes/IndividualEpisodePage.js
+++ b/nextjs/src/modules/episodes/IndividualEpisodePage.js
@@ -22,6 +22,7 @@ const IndividualEpisodePage = ({
   episode: {
     audioPath,
     briefDescription,
+    episodeCover,
     episodeNumber,
     episodeTranscript,
     guest,
@@ -51,7 +52,7 @@ const IndividualEpisodePage = ({
         publishedAt={publishedAt}
       />
       <div className="audio-player">
-        <WaveformPlayer episodeTitle={title} audioPath={audioPath} episodeNumber={episodeNumber} skipTo={skipTo} />
+        <WaveformPlayer artwork={episodeCover.asset.url} episodeTitle={title} audioPath={audioPath} episodeNumber={episodeNumber} skipTo={skipTo} />
       </div>
       <VerticalDivider />
 

--- a/nextjs/src/modules/shared/components/AudioPlayer/WaveformPlayer.js
+++ b/nextjs/src/modules/shared/components/AudioPlayer/WaveformPlayer.js
@@ -17,7 +17,7 @@ import { useAudioPlayer } from './hooks/AudioPlayer';
 /** -------------------------------------------------
 * COMPONENT
 ---------------------------------------------------- */
-const WaveformPlayer = ({ audioPath, episodeNumber, episodeTitle, skipTo }) => {
+const WaveformPlayer = ({ artwork = '/images/podcast-cover.jpg', audioPath, episodeNumber, episodeTitle, skipTo }) => {
   // references
   const audioPlayer = useRef(); // set up reference for the audio component
   const progressBar = useRef(); // reference for the progress bar
@@ -49,7 +49,7 @@ const WaveformPlayer = ({ audioPath, episodeNumber, episodeTitle, skipTo }) => {
 
       {/* album cover */}
       <div className="album-cover">
-        <img src="/images/placeholder__cover.png" alt="Episode Cover" />
+        <img src={artwork} alt="Episode Cover" />
       </div>
 
       {/* episode meta data */}

--- a/nextjs/src/pages/episode/[slug].js
+++ b/nextjs/src/pages/episode/[slug].js
@@ -3,7 +3,7 @@ import groq from 'groq';
 import { InteriorLayout } from 'modules/shared/layouts/InteriorLayout';
 import { IndividualEpisodePage } from 'modules/episodes/IndividualEpisodePage';
 
-export default function Episode({episode}) {
+export default function Episode({ episode }) {
   return (
     <InteriorLayout>
       <IndividualEpisodePage episode={episode} />
@@ -16,7 +16,11 @@ const query = groq`*[_type == "episode" && slug.current == $slug] {
   audioPath,
   briefDescription,
   categories[]->,
-  episodeCover,
+  episodeCover {
+    asset-> {
+      url
+    }
+  },
   episodeNumber,
   guest[]->{
     _id,
@@ -59,5 +63,5 @@ const query = groq`*[_type == "episode" && slug.current == $slug] {
 export async function getServerSideProps(context) {
   const { slug = '' } = context.query;
   const episode = await client.fetch(query, { slug });
-  return {props: {episode}}
+  return { props: { episode } }
 }


### PR DESCRIPTION
Fixes #71

## Feature description
- Wasn't pulling the correct cover artwork
- Before:
<img width="1364" alt="CleanShot 2021-10-06 at 00 06 15@2x" src="https://user-images.githubusercontent.com/212300/136144505-f01e395f-5fae-4cbb-a210-97d59d8e3dc0.png">

## Solution description
- Fixed query from Sanity
- Passed in the result as a prop
- Set up the default to pull from the main cover image

## Output Screenshots
<img width="1429" alt="CleanShot 2021-10-06 at 00 16 26@2x" src="https://user-images.githubusercontent.com/212300/136144556-6714f2fb-ae87-45c7-bbf6-7d0d0380dcda.png">

## Address affected and ensured
- Should only affect the individual episode page
