### PR TITLE
[gh74] Newsletter pages are generated on the server

### DIFF
--- a/nextjs/src/pages/newsletter/[slug].js
+++ b/nextjs/src/pages/newsletter/[slug].js
@@ -3,6 +3,9 @@ import groq from 'groq';
 import { InteriorLayout } from 'modules/shared/layouts/InteriorLayout';
 import { IndividualNewsletterPage } from 'modules/newsletter/IndividualNewsletterPage';
 
+// query
+import { AllNewslettersQuery } from "./index";
+
 export default function IndividualNewsletter({ newsletter }) {
   return (
     <InteriorLayout>
@@ -11,7 +14,7 @@ export default function IndividualNewsletter({ newsletter }) {
   );
 }
 
-const query = groq`*[_type == "newsletter" && slug.current == $slug] | order(dateSent desc) {
+const IndividualNewsletterQuery = groq`*[_type == "newsletter" && slug.current == $slug] | order(dateSent desc) {
   _id,
   subject,
   dateSent,
@@ -51,8 +54,27 @@ const query = groq`*[_type == "newsletter" && slug.current == $slug] | order(dat
   meta
 }[0]`;
 
-export async function getServerSideProps(context) {
-  const { slug = '' } = context.query;
-  const newsletter = await client.fetch(query, { slug });
-  return { props: { newsletter } };
+
+export async function getStaticPaths() {
+  const allNewsletters = await client.fetch(AllNewslettersQuery);
+
+  // Get the paths we want to pre-render based on episodes
+  const paths = allNewsletters.map((newsletter) => ({
+    params: { slug: newsletter.slug.current },
+  }))
+
+  return { paths, fallback: false }
+}
+
+// This function gets called at build time on server-side.
+// It may be called again, on a serverless function, if
+// revalidation is enabled and a new request comes in
+export async function getStaticProps({ params }) {
+  const { slug } = params;
+  const newsletter = await client.fetch(IndividualNewsletterQuery, { slug });
+  return {
+    props: {
+      newsletter
+    },
+  }
 }

--- a/nextjs/src/pages/newsletter/index.js
+++ b/nextjs/src/pages/newsletter/index.js
@@ -11,7 +11,7 @@ export default function Newsletter({ newsletters }) {
   );
 }
 
-const query = groq`*[_type == "newsletter" && published == true] | order(dateSent desc) {
+export const AllNewslettersQuery = groq`*[_type == "newsletter" && published == true] | order(dateSent desc) {
   _id,
   subject,
   dateSent,
@@ -19,6 +19,6 @@ const query = groq`*[_type == "newsletter" && published == true] | order(dateSen
 }`;
 
 export async function getServerSideProps(context) {
-  const newsletters = await client.fetch(query);
+  const newsletters = await client.fetch(AllNewslettersQuery);
   return { props: { newsletters } };
 }


### PR DESCRIPTION
Fixes #74 

## Feature description
The newsletter pages were not being generated on the server-side.

## Solution description
- Exported the query to retrieve all newsletters
- Made use of Next.js's `getStaticPaths` and `getStaticProps`
