### PR TITLE
Fix typo in About page

### DIFF
--- a/remix/app/routes/_interior.sponsoring/route.tsx
+++ b/remix/app/routes/_interior.sponsoring/route.tsx
@@ -70,7 +70,7 @@ export default function Sponsoring() {
           <li>
             <p className="large-body-copy">
               There are podcasts that focus on web development and podcasts that
-              focus on web development, but few, if any, account for both.{" "}
+              focus on web design, but few, if any, account for both.{" "}
             </p>
             <p>
               You don’t have to know code to be a good designer. You don’t have


### PR DESCRIPTION
Fixed a typo in the about page, assuming that the text should mention both web development and web design. It was mentioning web development twice.